### PR TITLE
fix json.unmarshal error

### DIFF
--- a/oidc/refresh_token.go
+++ b/oidc/refresh_token.go
@@ -14,7 +14,7 @@ import (
 // token to get a new access token.
 type RefreshResponse struct {
 	AccessToken      string `json:"access_token"`
-	ExpiresIn        string `json:"expires_in"`
+	ExpiresIn        int    `json:"expires_in"`
 	IDToken          string `json:"id_token"`
 	Scope            string `json:"scope"`
 	TokenType        string `json:"token_type"`


### PR DESCRIPTION
With _error handling enabled™_ we couldn't refresh jwt tokens anymore because the field _ExpiresIn_ failed to reflect.
We didn't notice that before because the field is unused and filled after all fields we have in use.

_Part of giantswarm/giantswarm#6145_