### PR TITLE
fix ExpiresIn type to int in OIDC

### DIFF
--- a/oidc/pkce.go
+++ b/oidc/pkce.go
@@ -34,7 +34,7 @@ const (
 // PKCEResponse represents the result we get from the PKCE flow.
 type PKCEResponse struct {
 	AccessToken      string `json:"access_token"`
-	ExpiresIn        string `json:"expires_in"`
+	ExpiresIn        int    `json:"expires_in"`
 	IDToken          string `json:"id_token"`
 	Scope            string `json:"scope"`
 	TokenType        string `json:"token_type"`


### PR DESCRIPTION
Changing the type of `ExpiresIn` from `string` to `int` to match request.