### PR TITLE
Don't persist custom endpoints to the config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Increase resiliency using custom endpoints in `ChooseEndpoint`, `ChooseScheme`, `ChooseToken` and `SetProvider`
-- When using custom endpoints, unknown endpoint configurations will not get persisted into the config file any more
-- When using custom endpoints, the custom endpoint will not be selected any more
+- When using custom endpoints, unknown endpoint configurations will not be persisted in the config file anymore
+- When using custom endpoints, the custom endpoint will not be selected anymore
 
 ## [0.2.1] 2020-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Increase resiliency using custom endpoints in `ChooseEndpoint`, `ChooseScheme`, `ChooseToken` and `SetProvider`
+- When using custom endpoints, unknown endpoint configurations will not get persisted into the config file any more
+- When using custom endpoints, the custom endpoint will not be selected any more
 
 ## [0.2.1] 2020-04-22
 

--- a/config/config.go
+++ b/config/config.go
@@ -403,6 +403,9 @@ func (c *configStruct) ChooseToken(endpoint, overridingToken string) string {
 
 	if overridingToken != "" {
 		if _, ok := c.endpoints[ep]; ok {
+			c.endpointsMutex.Lock()
+			defer c.endpointsMutex.Unlock()
+
 			c.endpoints[ep].Token = overridingToken
 		}
 
@@ -427,6 +430,9 @@ func (c *configStruct) ChooseScheme(endpoint string, CmdToken string) string {
 
 	if CmdToken != "" {
 		if _, ok := c.endpoints[ep]; ok {
+			c.endpointsMutex.Lock()
+			defer c.endpointsMutex.Unlock()
+
 			c.endpoints[ep].Scheme = "giantswarm"
 		}
 

--- a/config/config.go
+++ b/config/config.go
@@ -503,8 +503,17 @@ func (c *configStruct) SetProvider(provider string) error {
 
 	c.endpoints[c.SelectedEndpoint].Provider = provider
 	c.Provider = provider
-	// TODO teach gscliauth to abstain from writing to file if not desired
-	WriteToFile()
+
+	// ignore errors like a barbarian
+	conf, _ := readFromFile(FileSystem, ConfigFilePath)
+
+	// only write to the config file if the currently selected
+	// endpoint exists in the config file.
+	// This prevents writing endpoint configuration from
+	// command line flags to the file
+	if _, ok := conf.endpoints[c.SelectedEndpoint]; ok {
+		WriteToFile()
+	}
 
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -517,8 +517,10 @@ func (c *configStruct) SetProvider(provider string) error {
 	// endpoint exists in the config file.
 	// This prevents writing endpoint configuration from
 	// command line flags to the file
-	if _, ok := conf.endpoints[c.SelectedEndpoint]; ok {
-		WriteToFile()
+	if conf != nil {
+		if _, ok := conf.endpoints[c.SelectedEndpoint]; ok {
+			WriteToFile()
+		}
 	}
 
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -305,6 +305,12 @@ func (c *configStruct) ChooseEndpoint(overridingEndpointAliasOrURL string) strin
 		}
 
 		ep := normalizeEndpoint(overridingEndpointAliasOrURL)
+
+		// overwrite c.SelectedEndpoint to make the override accessible for
+		// other calls to the library
+		// Don't use c.SelectEndpoint() as it writes to the config file
+		c.SelectedEndpoint = ep
+
 		return ep
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -402,7 +402,9 @@ func (c *configStruct) ChooseToken(endpoint, overridingToken string) string {
 	ep := normalizeEndpoint(endpoint)
 
 	if overridingToken != "" {
-		c.endpoints[ep].Token = overridingToken
+		if _, ok := c.endpoints[ep]; ok {
+			c.endpoints[ep].Token = overridingToken
+		}
 
 		return overridingToken
 	}
@@ -424,7 +426,9 @@ func (c *configStruct) ChooseScheme(endpoint string, CmdToken string) string {
 	ep := normalizeEndpoint(endpoint)
 
 	if CmdToken != "" {
-		c.endpoints[ep].Scheme = "giantswarm"
+		if _, ok := c.endpoints[ep]; ok {
+			c.endpoints[ep].Scheme = "giantswarm"
+		}
 
 		return "giantswarm"
 	}
@@ -499,6 +503,7 @@ func (c *configStruct) SetProvider(provider string) error {
 
 	c.endpoints[c.SelectedEndpoint].Provider = provider
 	c.Provider = provider
+	// TODO teach gscliauth to abstain from writing to file if not desired
 	WriteToFile()
 
 	return nil


### PR DESCRIPTION
The changes in this PR aim to make working with `gsctl` and `--endpoint` and `--auth-token` flags more reliably.

I am assuming that users specifying `--endpoint` and `--auth-token` on `gsctl` calls don't want these credentials to end up in the config file and don't want to change their currently selected endpoint.

It also fixes `gsctl` printing `no endpoint selected error` behaviour when trying to `create cluster` with `--endpoint` flag without a `login` first.

The efforts were made to increase usability of `gsctl` for automation (and https://github.com/giantswarm/gsctl/pull/575)

## Checklist

- [x] Update changelog in CHANGELOG.md.
