### PR TITLE
switch to log.Logger based output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Switch to log.Logger based output
+
 ## [0.2.2] - 2020-08-20
 
 - Increase resiliency using custom endpoints in `ChooseEndpoint`, `ChooseScheme`, `ChooseToken` and `SetProvider`

--- a/config/config.go
+++ b/config/config.go
@@ -843,7 +843,7 @@ func normalizeEndpoint(u string) string {
 	}
 
 	if isHttp {
-		fmt.Fprintf(logger, "Warning: endpoint URL uses an insecure protocol")
+		fmt.Fprintf(logger, "Warning: endpoint URL uses an insecure protocol\n")
 	}
 
 	// strip extra stuff.

--- a/config/config.go
+++ b/config/config.go
@@ -81,7 +81,7 @@ var (
 	// SystemUser is the current system user as user.User (os/user).
 	SystemUser *user.User
 
-	logger io.Writer
+	logger io.Writer = os.Stdout
 )
 
 // configStruct is the top-level data structure used to serialize and

--- a/config/config.go
+++ b/config/config.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"fmt"
-	"log"
+	"io"
 	"math/rand"
 	"net/url"
 	"os"
@@ -81,8 +81,7 @@ var (
 	// SystemUser is the current system user as user.User (os/user).
 	SystemUser *user.User
 
-	// Logger is the logger instance
-	Logger *log.Logger
+	logger io.Writer
 )
 
 // configStruct is the top-level data structure used to serialize and
@@ -650,9 +649,8 @@ func init() {
 // execution can be triggered in a controlled way.
 // It's supposed to be called after init().
 // The configDirPath argument can be given to override the DefaultConfigDirPath.
-func Initialize(fs afero.Fs, configDirPath string) error {
-	Logger = log.New(os.Stdout, "", 0)
-	Logger.SetFlags(0)
+func initialize(fs afero.Fs, configDirPath string, loggerToUse io.Writer) error {
+	logger = loggerToUse
 
 	FileSystem = fs
 	// Reset our Config object. This is particularly necessary for running
@@ -717,16 +715,35 @@ func Initialize(fs afero.Fs, configDirPath string) error {
 		if err != nil {
 			// print error message, but don't interrupt the user.
 			if IsGarbageCollectionFailedError(err) {
-				Logger.Printf("Error in key pair garbage collection - no files deleted: %s\n", err.Error())
+				fmt.Fprintf(logger, "Error in key pair garbage collection - no files deleted: %s\n", err.Error())
 			} else if IsGarbageCollectionPartiallyFailedError(err) {
-				Logger.Printf("Error in key pair garbage collection - some files not deleted: %s\n", err.Error())
+				fmt.Fprintf(logger, "Error in key pair garbage collection - some files not deleted: %s\n", err.Error())
 			} else {
-				Logger.Printf("Error in key pair garbage collection: %s\n", err.Error())
+				fmt.Fprintf(logger, "Error in key pair garbage collection: %s\n", err.Error())
 			}
 		}
 	}
 
 	return nil
+}
+
+// Initialize sets up all configuration.
+// It's distinct from init() on purpose, so it's
+// execution can be triggered in a controlled way.
+// It's supposed to be called after init().
+// The configDirPath argument can be given to override the DefaultConfigDirPath.
+func Initialize(fs afero.Fs, configDirPath string) error {
+	return initialize(fs, configDirPath, os.Stdout)
+}
+
+// InitializeWithLogger sets up all configuration.
+// It's distinct from init() on purpose, so it's
+// execution can be triggered in a controlled way.
+// It's supposed to be called after init().
+// The configDirPath argument can be given to override the DefaultConfigDirPath.
+// the loggerToUse argument specifies the io.Writer to write log messages to.
+func InitializeWithLogger(fs afero.Fs, configDirPath string, loggerToUse io.Writer) error {
+	return initialize(fs, configDirPath, loggerToUse)
 }
 
 // populateConfigStruct assigns configuration values from the unmarshalled
@@ -826,13 +843,13 @@ func normalizeEndpoint(u string) string {
 	}
 
 	if isHttp {
-		Logger.Println("Warning: endpoint URL uses an insecure protocol")
+		fmt.Fprintf(logger, "Warning: endpoint URL uses an insecure protocol")
 	}
 
 	// strip extra stuff.
 	p, err := url.Parse(u)
 	if err != nil {
-		Logger.Printf("Warning: endpoint URL normalization yielded: %s\n", err)
+		fmt.Fprintf(logger, "Warning: endpoint URL normalization yielded: %s\n", err)
 	}
 
 	// remove everything but scheme and host.


### PR DESCRIPTION
Towards giantswarm/giantswarm#12975

This PR changes the stuff printed by this library to be printed from a `log.Logger`. The intent is to be able to call `config.Logger.SetOutput(ioutil.Discard)` in `gsctl` if users don't want output of the library.

This is mainly the warning `Warning: endpoint URL uses an insecure protocol`

## Checklist

- [x] Update changelog in CHANGELOG.md.
